### PR TITLE
OSquery extension

### DIFF
--- a/exercises/python_packages.py
+++ b/exercises/python_packages.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+import osquery
+
+@osquery.register_plugin
+class PythonPackagesTablePlugin(osquery.TablePlugin):
+    def name(self):
+        return "python_packages"
+
+    def columns(self):
+        return [
+            osquery.TableColumn(name="name", type=osquery.STRING),
+            osquery.TableColumn(name="version", type=osquery.STRING),
+        ]
+
+    def generate(self, context):
+        query_data = []
+
+        for package in __import__('pkg_resources').working_set:
+            row = {}
+            row["version"] = package.version
+            row["name"]    = package.project_name
+            query_data.append(row)
+    
+        return query_data
+
+
+if __name__ == "__main__":
+    osquery.start_extension(name="python_packages",
+                            version="0.0.1",)


### PR DESCRIPTION
- Rubab's Intro
- OSquery extension in python for listing installed python packages in the form of an OSquery's table. 